### PR TITLE
Fix isLowerCase and isLowerCase bug.

### DIFF
--- a/java/cldc1.1.1/com/sun/cldc/i18n/uclc/DefaultCaseConverter.java
+++ b/java/cldc1.1.1/com/sun/cldc/i18n/uclc/DefaultCaseConverter.java
@@ -1,7 +1,7 @@
 /*
  *   
  *
- * Copyright  1990-2007 Sun Microsystems, Inc. All Rights Reserved.
+ * Copyright  1990-2009 Sun Microsystems, Inc. All Rights Reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER
  * 
  * This program is free software; you can redistribute it and/or
@@ -29,17 +29,116 @@ package com.sun.cldc.i18n.uclc;
 import java.io.*;
 import com.sun.cldc.i18n.*;
 
+/**
+ * Default class converting the case of characters.
+ *
+ * @version 1.0 04/04/2000
+ */
 public class DefaultCaseConverter {
+
+   /**
+     * Determines if the specified character is a lowercase character.
+     * The default case converter in CLDC only supports the ISO Latin-1 
+     * range of characters.
+     * <p>
+     * Of the ISO Latin-1 characters (character codes 0x0000 through 0x00FF),
+     * the following are lowercase:
+     * <p>
+     * a b c d e f g h i j k l m n o p q r s t u v w x y z
+     * &#92;u00DF &#92;u00E0 &#92;u00E1 &#92;u00E2 &#92;u00E3 &#92;u00E4 &#92;u00E5 &#92;u00E6 &#92;u00E7
+     * &#92;u00E8 &#92;u00E9 &#92;u00EA &#92;u00EB &#92;u00EC &#92;u00ED &#92;u00EE &#92;u00EF &#92;u00F0
+     * &#92;u00F1 &#92;u00F2 &#92;u00F3 &#92;u00F4 &#92;u00F5 &#92;u00F6 &#92;u00F8 &#92;u00F9 &#92;u00FA
+     * &#92;u00FB &#92;u00FC &#92;u00FD &#92;u00FE &#92;u00FF
+     *
+     * @param   ch   the character to be tested.
+     * @return  <code>true</code> if the character is lowercase;
+     *          <code>false</code> otherwise.
+     * @since   JDK1.0
+     */
     public static boolean isLowerCase(char ch) {
-	return DefaultCaseConverter.toLowerCase(ch) == ch;
+        return (ch >= 'a'  && ch <= 'z')
+            || (ch >= 0xDF && ch <= 0xF6)
+            || (ch >= 0xF8 && ch <= 0xFF);
     }
 
+   /**
+     * Determines if the specified character is an uppercase character.
+     * The default case converter in CLDC only supports the ISO Latin-1 
+     * range of characters.
+     * <p>
+     * Of the ISO Latin-1 characters (character codes 0x0000 through 0x00FF),
+     * the following are uppercase:
+     * <p>
+     * A B C D E F G H I J K L M N O P Q R S T U V W X Y Z
+     * &#92;u00C0 &#92;u00C1 &#92;u00C2 &#92;u00C3 &#92;u00C4 &#92;u00C5 &#92;u00C6 &#92;u00C7
+     * &#92;u00C8 &#92;u00C9 &#92;u00CA &#92;u00CB &#92;u00CC &#92;u00CD &#92;u00CE &#92;u00CF &#92;u00D0
+     * &#92;u00D1 &#92;u00D2 &#92;u00D3 &#92;u00D4 &#92;u00D5 &#92;u00D6 &#92;u00D8 &#92;u00D9 &#92;u00DA
+     * &#92;u00DB &#92;u00DC &#92;u00DD &#92;u00DE
+     *
+     * @param   ch   the character to be tested.
+     * @return  <code>true</code> if the character is uppercase;
+     *          <code>false</code> otherwise.
+     * @see     java.lang.Character#isLowerCase(char)
+     * @see     java.lang.Character#toUpperCase(char)
+     * @since   1.0
+     */
     public static boolean isUpperCase(char ch) {
-	return DefaultCaseConverter.toUpperCase(ch) == ch;
+        return (ch >= 'A'  && ch <= 'Z')
+            || (ch >= 0xC0 && ch <= 0xD6)
+            || (ch >= 0xD8 && ch <= 0xDE );
     }
 
-    public static native char toLowerCase(char ch);
-    public static native char toUpperCase(char ch);
+    /**
+     * The given character is mapped to its lowercase equivalent; if the
+     * character has no lowercase equivalent, the character itself is
+     * returned.  The default case converter in CLDC only supports
+     * the ISO Latin-1 range of characters.
+     *
+     * @param   ch   the character to be converted.
+     * @return  the lowercase equivalent of the character, if any;
+     *          otherwise the character itself.
+     * @see     java.lang.Character#isLowerCase(char)
+     * @see     java.lang.Character#isUpperCase(char)
+     * @see     java.lang.Character#toUpperCase(char)
+     * @since   JDK1.0
+     */
+    public static char toLowerCase(char ch) {
+        if (isUpperCase(ch)) {
+            if (ch <= 'Z') {
+                return (char)(ch + ('a' - 'A'));
+            } else {
+                return (char)(ch + 0x20);
+            }
+        } else {
+            return ch;
+        }
+    }
+
+    /**
+     * Converts the character argument to uppercase; if the
+     * character has no lowercase equivalent, the character itself is
+     * returned.  The default case converter in CLDC only supports
+     * the ISO Latin-1 range of characters.
+     *
+     * @param   ch   the character to be converted.
+     * @return  the uppercase equivalent of the character, if any;
+     *          otherwise the character itself.
+     * @see     java.lang.Character#isLowerCase(char)
+     * @see     java.lang.Character#isUpperCase(char)
+     * @see     java.lang.Character#toLowerCase(char)
+     * @since   JDK1.0
+     */
+    public static char toUpperCase(char ch) {
+        if (isLowerCase(ch)) {
+            if (ch <= 'z') {
+                return (char)(ch - ('a' - 'A'));
+            } else {
+                return (char)(ch - 0x20);
+            }
+        } else {
+            return ch;
+        }
+    }
 
     /**
      * Determines if the specified character is a digit.
@@ -79,4 +178,5 @@ public class DefaultCaseConverter {
         }
         return (value < radix) ? value : -1;
     }
+
 }

--- a/native.js
+++ b/native.js
@@ -629,14 +629,6 @@ Native.create("com/sun/cldc/io/ResourceInputStream.readBytes.(Ljava/lang/Object;
     return (len > 0) ? len : -1;
 });
 
-Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toLowerCase.(C)C", function(char) {
-    return String.fromCharCode(char).toLowerCase().charCodeAt(0);
-});
-
-Native.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toUpperCase.(C)C", function(char) {
-    return String.fromCharCode(char).toUpperCase().charCodeAt(0);
-});
-
 Native.create("java/lang/ref/WeakReference.initializeWeakReference.(Ljava/lang/Object;)V", function(target) {
     this.target = target;
 });

--- a/override.js
+++ b/override.js
@@ -308,3 +308,11 @@ Override.create("com/sun/midp/security/Permissions.getId.(Ljava/lang/String;)I",
 Override.create("com/sun/midp/security/Permissions.getName.(I)Ljava/lang/String;", function(id) {
   return "com.sun.midp";
 });
+
+Override.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toLowerCase.(C)C", function(char) {
+    return String.fromCharCode(char).toLowerCase().charCodeAt(0);
+});
+
+Override.create("com/sun/cldc/i18n/uclc/DefaultCaseConverter.toUpperCase.(C)C", function(char) {
+    return String.fromCharCode(char).toUpperCase().charCodeAt(0);
+});

--- a/tests/RunTests.java
+++ b/tests/RunTests.java
@@ -44,8 +44,10 @@ public class RunTests extends MIDlet {
         }
 
         public void todo(boolean ok) {
-            if (ok)
+            if (ok) {
                 ++unknownPass;
+                debug("unknown pass");
+            }
             else
                 ++knownFail;
             ++testNumber;
@@ -53,7 +55,7 @@ public class RunTests extends MIDlet {
         }
 
         public void report() {
-            System.out.println(testName + ": " + pass + " pass, " + fail + " fail");
+            System.out.println(testName + ": " + pass + " pass, " + fail + " fail, " + unknownPass + " unknown pass");
         }
 
         public int passed() {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -67,9 +67,9 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71569 },
+  { name: "pass", number: 71570 },
   { name: "fail", number: 0 },
-  { name: "known fail", number: 180 },
+  { name: "known fail", number: 179 },
   { name: "unknown pass", number: 0 }
 ];
 

--- a/tests/gnu/testlet/java/lang/Long/new_Long.java
+++ b/tests/gnu/testlet/java/lang/Long/new_Long.java
@@ -113,7 +113,7 @@ public class new_Long implements Testlet
 	{
 	  ok = true;
 	}
-      harness.todo (ok);
+      harness.check (ok);
 
       ok = false;
       try


### PR DESCRIPTION
j2me divides all characters into 3 groups: 
1. lowercase, such as `a`, `b`, ...
2. uppercase, such as `A`, `B`, ...
3. others, such as `;`, `你`, ...

The characters from the 3rd group are not case sensitive, such as punctuation symbols. They doesn't fall into either the lowercase or uppercase group. So calling `isLowerCase()` and `isUpperCase()` over these characters should always return false.

But commit 76801f1c669a9a7 modified the original methods and made `isLowerCase()` and `isUpperCase()` return true over these case insensitive characters.

I reverted the changes to `isLowerCase()` and `isUpperCase()` to recover the original behavior. 