### PR TITLE
Class.forName should reports the correct name of ClassNotFoundException

### DIFF
--- a/native.js
+++ b/native.js
@@ -318,7 +318,7 @@ Native.create("java/lang/Class.forName.(Ljava/lang/String;)Ljava/lang/Class;", f
         classInfo = CLASSES.getClass(className);
     } catch (e) {
         if (e instanceof (Classes.ClassNotFoundException))
-            throw new JavaException("java/lang/ClassNotFoundException", "'" + className + "' not found.");
+            throw new JavaException("java/lang/ClassNotFoundException", "'" + e.message + "' not found.");
         throw e;
     }
     return classInfo.getClassObject(ctx);


### PR DESCRIPTION
If class `A` imports a missing class `B`, `Class.forName("A")` will report `A` is not found exception other than `B` is not found.

This patch fixes this and let `Class.forName` report correct name of `ClassNotFoundException`.