### PR TITLE
switch to new container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,4 @@ before_script:
   - export SLIMERJSLAUNCHER=/tmp/xulrunner/xulrunner
 script:
   - make test
+sudo: false


### PR DESCRIPTION
Switching to the [new container-based infrastructure](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) on Travis should make our builds faster. Currently, they tend to take over five minutes, like this recent one that took 5 min 14 sec:

https://travis-ci.org/andreasgal/j2me.js/builds/46750116

Whereas the build for this change to use the container-based infrastructure took 4 min 13 sec:

https://travis-ci.org/mykmelez/j2me.js/builds/46799276
