### PR TITLE
cache node modules and SlimerJS/XULRunner packages (fixes #847)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,16 @@ env:
 before_script:
   - "sh -e /etc/init.d/xvfb start"
   - npm install casperjs
-  - wget https://ftp.mozilla.org/pub/mozilla.org/labs/j2me.js/slimerjs-0.10.0pre-2014-12-17.zip
-  - unzip -d /tmp slimerjs-0.10.0pre-2014-12-17.zip
+  - wget -P /tmp/j2me.js -N https://ftp.mozilla.org/pub/mozilla.org/labs/j2me.js/slimerjs-0.10.0pre-2014-12-17.zip
+  - unzip -d /tmp /tmp/j2me.js/slimerjs-0.10.0pre-2014-12-17.zip
   - export PATH=$PATH:/tmp/slimerjs-0.10.0pre
-  - wget https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/31.0/runtimes/xulrunner-31.0.en-US.linux-x86_64.tar.bz2
-  - tar x -C /tmp -f xulrunner-31.0.en-US.linux-x86_64.tar.bz2
+  - wget -P /tmp/j2me.js -N https://ftp.mozilla.org/pub/mozilla.org/xulrunner/releases/31.0/runtimes/xulrunner-31.0.en-US.linux-x86_64.tar.bz2
+  - tar x -C /tmp -f /tmp/j2me.js/xulrunner-31.0.en-US.linux-x86_64.tar.bz2
   - export SLIMERJSLAUNCHER=/tmp/xulrunner/xulrunner
 script:
   - make test
 sudo: false
+cache:
+  directories:
+    - node_modules
+    - /tmp/j2me.js


### PR DESCRIPTION
Now that we're using Travis's container-based infrastructure, we can cache some dependencies. This change caches local node modules and the SlimerJS/XULRunner packages (both of which it now downloads to */tmp/j2me.js/*, since Travis can only cache arbitrary directories, not arbitrary individual files).

(We might also be able to cache the SlimerJS/XULRunner installations, but I'd have to think through that more carefully, since "installation" of those packages is currently just unzip/tar, which might not update the installations correctly when the packages get updated.)

Here's the first build with this change, where you can see the cache being created:

https://travis-ci.org/mykmelez/j2me.js/builds/46804315

And here's an empty change I pushed so you can see it being restored and used:

https://travis-ci.org/mykmelez/j2me.js/builds/46804632

Strangely, *casperjs* node module installation is still almost as expensive (6.76s to 5.25s), even though it should have been cached. *SlimerJS* is significantly cheaper (1.11s to 0.35s), although the lightweight edition is so small that the difference is negligible to overall build times. And *XULRunner* is much cheaper (7.60s to 0.34s), which is significant, since I've seen download times for that file as high as 25s.

Nevertheless, note that it took 6.41s to restore the cache, so it's only worth it for XULRunner:

> $ export CASHER_DIR=$HOME/.casher
> 0.10s $ Installing caching utilities
> 0.96s attempting to download cache archive
> found cache
> 2.68s adding /home/travis/build/mykmelez/j2me.js/node_modules to cache
> 2.67s adding /tmp/j2me.js to cache
