### PR TITLE
move configuration from launch path params to midlet.js

### DIFF
--- a/classinfo.js
+++ b/classinfo.js
@@ -95,7 +95,7 @@ function MethodInfo(opts) {
       this.consumes++;
     }
 
-    this.numCalled = urlParams.numCalled || 0;
+    this.numCalled = config.numCalled || 0;
     this.compiled = null;
     this.dontCompile = false;
 }

--- a/index.html
+++ b/index.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" type="text/css" href="style/index.css">
   <script type="text/javascript" src="libs/load.js" defer></script>
   <script type="text/javascript" src="libs/promise-6.0.0.js" defer></script>
+  <script type="text/javascript" src="midlet.js" defer></script>
   <script type="text/javascript" src="libs/urlparams.js" defer></script>
   <script type="text/javascript" src="timer.js" defer></script>
   <script type="text/javascript" src="index.js" defer></script>

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@
  * Pre-load dependencies and then load the main page.
  */
 (function() {
-  var midletClassName = urlParams.midletClassName ? urlParams.midletClassName.replace(/\//g, '.') : "RunTests";
+  var midletClassName = config.midletClassName ? config.midletClassName.replace(/\//g, '.') : "RunTests";
   var loadingPromises = [];
   if (midletClassName == "RunTests") {
     loadingPromises.push(loadScript("tests/contacts.js"),
@@ -128,13 +128,13 @@ DumbPipe.registerOpener("mobileInfo", function(message, sender) {
   // for testing/debugging on a desktop.
   var mobileInfo = {
     network: {
-      mcc: urlParams.network_mcc || "310", // United States
-      mnc: urlParams.network_mnc || "001",
+      mcc: config.network_mcc || "310", // United States
+      mnc: config.network_mnc || "001",
     },
     icc: {
-      mcc: urlParams.icc_mcc || "310", // United States
-      mnc: urlParams.icc_mnc || "001",
-      msisdn: urlParams.icc_msisdn || "10005551212",
+      mcc: config.icc_mcc || "310", // United States
+      mnc: config.icc_mnc || "001",
+      msisdn: config.icc_msisdn || "10005551212",
     },
   };
 

--- a/instrument.js
+++ b/instrument.js
@@ -11,7 +11,7 @@ var Instrument = {
   profile: null,
   asyncProfile: null,
 
-  enabled: "instrument" in urlParams && !/no|0/.test(urlParams.instrument),
+  enabled: "instrument" in config && !/no|0/.test(config.instrument),
 
   callEnterHooks: function(methodInfo, caller, callee) {
     if (this.enabled) {

--- a/jsshell.js
+++ b/jsshell.js
@@ -48,7 +48,7 @@ var document = {
   },
 };
 
-var urlParams = {
+var config = {
   logConsole: "native",
   args: "",
 };
@@ -74,6 +74,6 @@ print("INITIALIZATION TIME: " + (dateNow() - start));
 
 start = dateNow();
 
-jvm.startIsolate0(scriptArgs[0], urlParams.args);
+jvm.startIsolate0(scriptArgs[0], config.args);
 
 print("RUNNING TIME: " + (dateNow() - start));

--- a/libs/console.js
+++ b/libs/console.js
@@ -22,8 +22,8 @@
    *    page: the in-page console (an HTML element with ID "console")
    *    native: the native console (via the *dump* function)
    */
-  var ENABLED_CONSOLE_TYPES = (urlParams.logConsole || "page").split(",");
-  var minLogLevel = LOG_LEVELS[urlParams.logLevel || "log"];
+  var ENABLED_CONSOLE_TYPES = (config.logConsole || "page").split(",");
+  var minLogLevel = LOG_LEVELS[config.logLevel || "log"];
 
 
   //================================================================

--- a/libs/urlparams.js
+++ b/libs/urlparams.js
@@ -42,5 +42,9 @@ var urlParams = (function() {
 
   params.args = (params.args || "").split(",");
 
+  for (var name in params) {
+    config[name] = params[name];
+  }
+
   return params;
 })();

--- a/main.html
+++ b/main.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" type="text/css" href="style/progress_activity.css">
 
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1">
+  <script type="text/javascript" src="midlet.js" defer></script>
   <script type="text/javascript" src="libs/urlparams.js" defer></script>
   <script type="text/javascript" src="libs/console.js" defer></script>
   <script type="text/javascript" src="legacy.js" defer></script>
@@ -65,7 +66,6 @@
   <script type="text/javascript" src="game-ui.js" defer></script>
   <script type="text/javascript" src="desktop-ui.js" defer></script>
   <script type="text/javascript" src="main.js" defer></script>
-  <script type="text/javascript" src="midlet.js" defer></script>
 </head>
 
 <body>

--- a/main.js
+++ b/main.js
@@ -15,10 +15,10 @@ var APP_BASE_DIR = "./";
 
 var jvm = new JVM();
 
-var main = urlParams.main || "com/sun/midp/main/MIDletSuiteLoader";
-MIDP.midletClassName = urlParams.midletClassName ? urlParams.midletClassName.replace(/\//g, '.') : "RunTests";
+var main = config.main || "com/sun/midp/main/MIDletSuiteLoader";
+MIDP.midletClassName = config.midletClassName ? config.midletClassName.replace(/\//g, '.') : "RunTests";
 
-if ("gamepad" in urlParams && !/no|0/.test(urlParams.gamepad)) {
+if ("gamepad" in config && !/no|0/.test(config.gamepad)) {
   document.documentElement.classList.add('gamepad');
 }
 
@@ -28,14 +28,14 @@ if (MIDP.midletClassName == "RunTests") {
   jars.push("tests/tests.jar");
 }
 
-if (urlParams.jars) {
-  jars = jars.concat(urlParams.jars.split(":"));
+if (config.jars) {
+  jars = jars.concat(config.jars.split(":"));
 }
 
-if (urlParams.pushConn && urlParams.pushMidlet) {
+if (config.pushConn && config.pushMidlet) {
   MIDP.ConnectionRegistry.addConnection({
-    connection: urlParams.pushConn,
-    midlet: urlParams.pushMidlet,
+    connection: config.pushConn,
+    midlet: config.pushMidlet,
     filter: "*",
     suiteId: "1"
   });
@@ -78,8 +78,8 @@ function processJAD(data) {
   });
 }
 
-if (urlParams.jad) {
-  loadingPromises.push(load(urlParams.jad, "text").then(processJAD));
+if (config.jad) {
+  loadingPromises.push(load(config.jad, "text").then(processJAD));
 }
 
 function performDownload(url, dialog, callback) {
@@ -129,7 +129,7 @@ function performDownload(url, dialog, callback) {
   });
 }
 
-if (urlParams.downloadJAD) {
+if (config.downloadJAD) {
   loadingPromises.push(initFS.then(function() {
     return new Promise(function(resolve, reject) {
       fs.exists("/midlet.jar", function(exists) {
@@ -156,7 +156,7 @@ if (urlParams.downloadJAD) {
           dialog.classList.add('visible');
           document.body.appendChild(dialog);
 
-          performDownload(urlParams.downloadJAD, dialog, function(data) {
+          performDownload(config.downloadJAD, dialog, function(data) {
             dialog.parentElement.removeChild(dialog);
 
             jvm.addPath("midlet.jar", data.jarData);
@@ -185,7 +185,7 @@ if (MIDP.midletClassName == "RunTests") {
 
 Promise.all(loadingPromises).then(function() {
   jvm.initializeBuiltinClasses();
-  jvm.startIsolate0(main, urlParams.args);
+  jvm.startIsolate0(main, config.args);
 });
 
 function getIsOff(button) {
@@ -231,6 +231,6 @@ window.onload = function() {
  }
 };
 
-if (urlParams.profile && !/no|0/.test(urlParams.profile)) {
+if (config.profile && !/no|0/.test(config.profile)) {
   Instrument.startProfile();
 }

--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,7 +1,7 @@
 {
   "name": "j2me.js",
   "description": "j2me interpreter for firefox os",
-  "launch_path": "/index.html?autosize=1&logConsole=web",
+  "launch_path": "/index.html",
   "origin": "app://j2mejs.mozilla.org",
   "icons": {
     "128": "/img/icon-128.png"

--- a/midlet.js
+++ b/midlet.js
@@ -10,3 +10,6 @@ var MIDlet = {
     return message;
   },
 };
+
+var config = {
+};

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -295,7 +295,7 @@ var currentlyFocusedTextEditor;
     var SIZE_LARGE = 16;
 
     Native.create("javax/microedition/lcdui/Font.init.(III)V", function(face, style, size) {
-        var defaultSize = urlParams.fontSize ? urlParams.fontSize : Math.max(10, (MIDP.Context2D.canvas.height / 35) | 0);
+        var defaultSize = config.fontSize ? config.fontSize : Math.max(10, (MIDP.Context2D.canvas.height / 35) | 0);
         if (size & SIZE_SMALL)
             size = defaultSize / 1.25;
         else if (size & SIZE_LARGE)

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -281,7 +281,7 @@ Native.create("com/sun/midp/main/CommandState.restoreCommandState.(Lcom/sun/midp
     var suiteId = (MIDP.midletClassName === "internal") ? -1 : 1;
     state.class.getField("I.suiteId.I").set(state, suiteId);
     state.class.getField("I.midletClassName.Ljava/lang/String;").set(state, util.newString(MIDP.midletClassName));
-    var args = urlParams.args;
+    var args = config.args;
     state.class.getField("I.arg0.Ljava/lang/String;").set(state, util.newString((args.length > 0) ? args[0] : ""));
     state.class.getField("I.arg1.Ljava/lang/String;").set(state, util.newString((args.length > 1) ? args[1] : ""));
     state.class.getField("I.arg2.Ljava/lang/String;").set(state, util.newString((args.length > 2) ? args[2] : ""));
@@ -585,7 +585,7 @@ Native.create("com/sun/midp/chameleon/layers/SoftButtonLayer.isNativeSoftButtonL
 MIDP.Context2D = (function() {
     var c = document.getElementById("canvas");
 
-    if (urlParams.autosize && !/no|0/.test(urlParams.autosize)) {
+    if (config.autosize && !/no|0/.test(config.autosize)) {
       c.width = window.innerWidth;
       c.height = window.innerHeight;
       document.documentElement.classList.add('autosize');

--- a/native.js
+++ b/native.js
@@ -69,7 +69,7 @@ Native.create("java/lang/System.getProperty0.(Ljava/lang/String;)Ljava/lang/Stri
         value = navigator.language;
         break;
     case "microedition.platform":
-        value = urlParams.platform ? urlParams.platform : "Nokia503/14.0.4/java_runtime_version=Nokia_Asha_1_2";
+        value = config.platform ? config.platform : "Nokia503/14.0.4/java_runtime_version=Nokia_Asha_1_2";
         break;
     case "microedition.platformimpl":
         value = null;


### PR DESCRIPTION
Unfortunately, the Marketplace validator rejects query parameters in launch paths because of [bug 943710](https://bugzilla.mozilla.org/show_bug.cgi?id=943710), so this makes them configurable via a *config* Object defined in midlet.js.

It isn't entirely functionally equivalent, since the query parameters allow us to specify parameters that only apply when the app is installed as an app (as opposed to being loaded in the browser). But it's close enough.

I've tested and confirmed that I can configure the project for a midlet, package it, run the midlet on a device as before, and pass validation on Marketplace.
