### PR TITLE
wait longer before timing out; dump screenshot on timeout

### DIFF
--- a/tests/fs/automation.js
+++ b/tests/fs/automation.js
@@ -7,9 +7,14 @@ casper.on('remote.message', function(message) {
     this.echo(message);
 });
 
-casper.options.waitTimeout = 30000;
+casper.options.waitTimeout = 60000;
 casper.options.verbose = true;
 casper.options.logLevel = "debug";
+
+casper.options.onWaitTimeout = function() {
+    this.echo("data:image/png;base64," + this.captureBase64('png'));
+    this.test.fail("Timeout");
+};
 
 casper.test.begin("fs tests", 7, function(test) {
     // The main test automation script already initializes the fs database


### PR DESCRIPTION
The fs automation tests tend to time out on one of my Linux VMs, presumably because that machine is slower than the host machine. I also see timeouts on the host machine when I enable fs debugging, which generates a bunch more log output. And I've still seen intermittent timeouts on Travis, although they're rarer since we bumped the wait timeout from 15 to 30 seconds.

So this branch bumps it to 60 seconds and adds a handler that dumps a screenshot URL if it still times out.
