### PR TITLE
bump max different pixels for emoji strings on Mac

### DIFF
--- a/tests/automation.js
+++ b/tests/automation.js
@@ -58,13 +58,13 @@ var gfxTests = [
   { name: "gfx/DrawStringBottomAnchorTest", maxDifferent: 347 },
   { name: "gfx/DrawStringHCenterAnchorTest", maxDifferent: 333 },
   { name: "gfx/RectAfterText", maxDifferent: 637 },
-  { name: "gfx/DrawStringWithEmojiTest", maxDifferent: 936 },
-  { name: "gfx/DrawSubstringWithEmojiTest", maxDifferent: 936 },
-  { name: "gfx/DrawCharsWithEmojiTest", maxDifferent: 936 },
+  { name: "gfx/DrawStringWithEmojiTest", maxDifferent: 1060 },
+  { name: "gfx/DrawSubstringWithEmojiTest", maxDifferent: 1060 },
+  { name: "gfx/DrawCharsWithEmojiTest", maxDifferent: 1060 },
   { name: "gfx/CreateImmutableCopyTest", maxDifferent: 0 },
   { name: "gfx/LauncherTest", maxDifferent: 0 },
   { name: "gfx/MediaImageTest", maxDifferent: 0 },
-  { name: "gfx/TextEditorGfxTest", maxDifferent: 949 },
+  { name: "gfx/TextEditorGfxTest", maxDifferent: 953 },
 ];
 
 var expectedUnitTestResults = [


### PR DESCRIPTION
On Mac, these tests produce larger numbers of differing pixels because of a different font weight. For example, here's DrawStringWithEmojiTest (reference on left, my result on right):

![drawstringwithemojitest](https://cloud.githubusercontent.com/assets/305455/5825507/af9ffd7c-a0a0-11e4-9564-8a4419e8ce9d.png) ![drawstringwithemojitest-result](https://cloud.githubusercontent.com/assets/305455/5825512/bba601de-a0a0-11e4-9228-f14f9469e49c.png)

