### PR TITLE
Remove gfx closures

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -440,7 +440,7 @@ var currentlyFocusedTextEditor;
         }
     }
 
-    function withTextAnchor(g, c, anchor, x, y, str, cb) {
+    function withTextAnchor(g, c, anchor, x, y, str) {
         withFont(g.klass.classInfo.getField("I.currentFont.Ljavax/microedition/lcdui/Font;").get(g), c);
 
         c.textAlign = "left";
@@ -464,7 +464,7 @@ var currentlyFocusedTextEditor;
             throw $.newIllegalArgumentException("VCENTER not allowed with text");
         }
 
-        cb(x, y);
+        return [x, y];
     }
 
     function abgrIntToCSS(pixel) {
@@ -673,17 +673,16 @@ var currentlyFocusedTextEditor;
             var [curX, curY] = withClip(g, c, x, y);
             parseEmojiString(str).forEach(function(part) {
                 if (part.text) {
-                    withTextAnchor(g, c, anchor, curX, curY, part.text, function(x, y) {
-                        var withPixelFunc = isOpaque ? withOpaquePixel : withPixel;
-                        withPixelFunc(g, c, function() {
-                            c.fillText(part.text, x, y);
+                    var [textX, textY] = withTextAnchor(g, c, anchor, curX, curY, part.text);
+                    var withPixelFunc = isOpaque ? withOpaquePixel : withPixel;
+                    withPixelFunc(g, c, function() {
+                        c.fillText(part.text, textX, textY);
 
-                            // If there are emojis in the string that we need to draw,
-                            // we need to calculate the string width
-                            if (part.emoji) {
-                                curX += measureWidth(c, part.text)
-                            }
-                        });
+                        // If there are emojis in the string that we need to draw,
+                        // we need to calculate the string width
+                        if (part.emoji) {
+                            curX += measureWidth(c, part.text)
+                        }
                     });
                 }
 
@@ -714,10 +713,9 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
-            withTextAnchor(g, c, anchor, x, y, chr, function(x, y) {
-                withPixel(g, c, function() {
-                    c.fillText(chr, x, y);
-                });
+            [x, y] = withTextAnchor(g, c, anchor, x, y, chr);
+            withPixel(g, c, function() {
+                c.fillText(chr, x, y);
             });
         });
     };

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -543,14 +543,6 @@ var currentlyFocusedTextEditor;
         createEllipticalArc(c, x + rw, y + rh, rw, rh, Math.PI, 1.5 * Math.PI, false);
     }
 
-    function withSize(dx, dy, cb) {
-        if (!dx)
-            dx = 1;
-        if (!dy)
-            dy = 1;
-        cb(dx, dy);
-    }
-
     Native["javax/microedition/lcdui/Graphics.getDisplayColor.(I)I"] = function(color) {
         return color;
     };
@@ -715,8 +707,11 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
+
             [x, y] = withTextAnchor(g, c, anchor, x, y, chr);
+
             withPixel(g, c);
+
             c.fillText(chr, x, y);
         });
     };
@@ -725,17 +720,20 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             var [x, y] = withClip(g, c, x1, y1);
+
             withPixel(g, c);
-            withSize(x2 - x1, y2 - y1, function(dx1, dy1) {
-                withSize(x3 - x1, y3 - y1, function(dx2, dy2) {
-                    c.beginPath();
-                    c.moveTo(x, y);
-                    c.lineTo(x + dx1, y + dy1);
-                    c.lineTo(x + dx2, y + dy2);
-                    c.closePath();
-                    c.fill();
-                });
-            });
+
+            var dx1 = (x2 - x1) || 1;
+            var dy1 = (y2 - y1) || 1;
+            var dx2 = (x3 - x1) || 1;
+            var dy2 = (y3 - y1) || 1;
+
+            c.beginPath();
+            c.moveTo(x, y);
+            c.lineTo(x + dx1, y + dy1);
+            c.lineTo(x + dx2, y + dy2);
+            c.closePath();
+            c.fill();
         });
     };
 
@@ -746,10 +744,13 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
+
             withPixel(g, c);
-            withSize(w, h, function(w, h) {
-                c.strokeRect(x, y, w, h);
-            });
+
+            w = w || 1;
+            h = h || 1;
+
+            c.strokeRect(x, y, w, h);
         });
     };
 
@@ -760,12 +761,15 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
+
             withPixel(g, c);
-            withSize(w, h, function(w, h) {
-                c.beginPath();
-                createRoundRect(c, x, y, w, h, arcWidth, arcHeight);
-                c.stroke();
-            });
+
+            w = w || 1;
+            h = h || 1;
+
+            c.beginPath();
+            createRoundRect(c, x, y, w, h, arcWidth, arcHeight);
+            c.stroke();
         });
     };
 
@@ -776,10 +780,13 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
+
             withPixel(g, c);
-            withSize(w, h, function(w, h) {
-                c.fillRect(x, y, w, h);
-            });
+
+            w = w || 1;
+            h = h || 1;
+
+            c.fillRect(x, y, w, h);
         });
     };
 
@@ -790,12 +797,15 @@ var currentlyFocusedTextEditor;
         var g = this;
         withGraphics(g, function(c) {
             [x, y] = withClip(g, c, x, y);
+
             withPixel(g, c);
-            withSize(w, h, function(w, h) {
-                c.beginPath();
-                createRoundRect(c, x, y, w, h, arcWidth, arcHeight);
-                c.fill();
-            });
+
+            w = w || 1;
+            h = h || 1;
+
+            c.beginPath();
+            createRoundRect(c, x, y, w, h, arcWidth, arcHeight);
+            c.fill();
         });
     };
 
@@ -872,18 +882,20 @@ var currentlyFocusedTextEditor;
     };
 
     Native["javax/microedition/lcdui/Graphics.drawLine.(IIII)V"] = function(x1, y1, x2, y2) {
-        var dx = x2 - x1, dy = y2 - y1;
         var g = this;
         withGraphics(g, function(c) {
             var [x, y] = withClip(g, c, x1, y1);
-            withSize(dx, dy, function(dx, dy) {
-                withPixel(g, c);
-                c.beginPath();
-                c.moveTo(x, y);
-                c.lineTo(x + dx, y + dy);
-                c.stroke();
-                c.closePath();
-            });
+
+            withPixel(g, c);
+
+            var dx = (x2 - x1) || 1;
+            var dy = (y2 - y1) || 1;
+
+            c.beginPath();
+            c.moveTo(x, y);
+            c.lineTo(x + dx, y + dy);
+            c.stroke();
+            c.closePath();
         });
     };
 

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -949,11 +949,11 @@ var currentlyFocusedTextEditor;
         var c = withGraphics(this);
         c.save();
 
-        [x, y] = withClip(g, c, x, y);
+        [x, y] = withClip(this, c, x, y);
 
         c.drawImage(context.canvas, x, y);
 
-        c.restore(),
+        c.restore();
     };
 
     var textEditorId = 0,

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -819,9 +819,9 @@ var currentlyFocusedTextEditor;
         var c = withGraphics(this);
         c.save();
 
-        [x, y] = withClip(g, c, x, y);
+        [x, y] = withClip(this, c, x, y);
 
-        withPixel(g, c);
+        withPixel(this, c);
 
         w = w || 1;
         h = h || 1;


### PR DESCRIPTION
This PR is removing the callback arguments from withClip, withAnchor, withTextAnchor, withOpaquePixel, withPixel, withSize, withGraphics.
The flickering I was experiencing with a MIDlet seems to be gone after this changeset.

It might be easier to review one commit at a time, but the changes are straightforward overall.