### PR TITLE
Allow app to exit

### DIFF
--- a/index.js
+++ b/index.js
@@ -534,3 +534,7 @@ DumbPipe.registerOpener("windowOpen", function(message, sender) {
 DumbPipe.registerOpener("reload", function(message, sender) {
   window.location.reload();
 });
+
+DumbPipe.registerOpener("exit", function(message, sender) {
+  window.close();
+});

--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -31,7 +31,6 @@ module J2ME {
     "com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V": YieldReason.Root,
     "com/sun/midp/util/isolate/InterIsolateMutex.lock0.(I)V": YieldReason.Root,
     "com/sun/midp/events/NativeEventMonitor.waitForNativeEvent.(Lcom/sun/midp/events/NativeEvent;)I": YieldReason.Root,
-    "com/sun/midp/main/CommandState.exitInternal.(I)V": YieldReason.Root,
     "com/sun/midp/io/j2me/push/ConnectionRegistry.poll0.(J)I": YieldReason.Root,
     "com/sun/midp/rms/RecordStoreUtil.exists.(Ljava/lang/String;Ljava/lang/String;I)Z": YieldReason.Root,
     "com/sun/midp/rms/RecordStoreUtil.deleteFile.(Ljava/lang/String;Ljava/lang/String;I)V": YieldReason.Root,

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -867,6 +867,7 @@ Native["com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V"] = function(id
 };
 
 MIDP.exit = function(code) {
+    $.pause("exit");
     DumbPipe.open("exit", null, function(message) {});
 };
 

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -1046,7 +1046,7 @@ Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/Comm
 
 Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(exit) {
     console.info("Exit: " + exit);
-    asyncImpl("V", new Promise(function(){}));
+    DumbPipe.open("exit", null, function(message) {});
 };
 
 Native["com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z"] = function() {
@@ -1326,6 +1326,17 @@ Native["com/sun/j2me/content/AppProxy.isInSvmMode.()Z"] = function() {
     return 0;
 };
 
-Native["com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V"] = function(suiteID, className, cleanup) {
-    console.warn("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V not implemented");
-};
+Native["com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V"] =
+    UnimplementedNative("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V");
+
+Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] =
+    UnimplementedNative("com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I", 0);
+
+Native["com/sun/j2me/content/InvocationStore.getByTid0.(Lcom/sun/j2me/content/InvocationImpl;II)I"] =
+    UnimplementedNative("com/sun/j2me/content/InvocationStore.getByTid0.(Lcom/sun/j2me/content/InvocationImpl;II)I", 0);
+
+Native["com/sun/j2me/content/InvocationStore.resetFlags0.(I)V"] =
+    UnimplementedNative("com/sun/j2me/content/InvocationStore.resetFlags0.(I)V");
+
+Native["com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V"] =
+    UnimplementedNative("com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V");

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -866,6 +866,15 @@ Native["com/sun/midp/util/isolate/InterIsolateMutex.unlock0.(I)V"] = function(id
     }
 };
 
+MIDP.exit = function(code) {
+    DumbPipe.open("exit", null, function(message) {});
+};
+
+Native["com/sun/cldc/isolate/Isolate.stop.(II)V"] = function(code, reason) {
+    console.info("Isolate stops with code " + code + " and reason " + reason);
+    MIDP.exit();
+};
+
 // The foreground isolate will get the user events (keypresses, etc.)
 MIDP.foregroundIsolateId;
 MIDP.nativeEventQueues = {};
@@ -1046,7 +1055,7 @@ Native["com/sun/midp/main/CommandState.saveCommandState.(Lcom/sun/midp/main/Comm
 
 Native["com/sun/midp/main/CommandState.exitInternal.(I)V"] = function(exit) {
     console.info("Exit: " + exit);
-    DumbPipe.open("exit", null, function(message) {});
+    MIDP.exit();
 };
 
 Native["com/sun/midp/suspend/SuspendSystem$MIDPSystem.allMidletsKilled.()Z"] = function() {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1171,7 +1171,7 @@ module J2ME {
         // Some Native MethodInfos are constructed but never called;
         // that's fine, unless we actually try to call them.
         return function missingImplementation() {
-          release || assert (false, "Method " + methodInfo.name + " is native but does not have an implementation.");
+          stderrWriter.errorLn("implKey " + methodInfo.name + " is native but does not have an implementation.");
         }
       }
     } else if (implKey in Override) {

--- a/tests/midlets/jaddownloader/AMIDletUpdater.java
+++ b/tests/midlets/jaddownloader/AMIDletUpdater.java
@@ -3,6 +3,8 @@ package tests.jaddownloader;
 import javax.microedition.midlet.MIDlet;
 import javax.microedition.io.ConnectionNotFoundException;
 
+import com.sun.cldc.isolate.Isolate;
+
 public class AMIDletUpdater extends MIDlet {
     public void startApp() {
         try {
@@ -11,6 +13,7 @@ public class AMIDletUpdater extends MIDlet {
             e.printStackTrace();
             System.out.println("FAIL");
         }
+        Isolate.currentIsolate().exit(0);
     }
 
     public void pauseApp() {

--- a/utilities.ts
+++ b/utilities.ts
@@ -53,7 +53,7 @@ function warn(message?: any, ...optionalParams: any[]): void {
   if (inBrowser) {
     console.warn.apply(console, arguments);
   } else {
-    jsGlobal.print(J2ME.IndentingWriter.RED + message + J2ME.IndentingWriter.ENDC);
+    jsGlobal.print(J2ME.IndentingWriter.YELLOW + message + J2ME.IndentingWriter.ENDC);
   }
 }
 
@@ -274,11 +274,6 @@ module J2ME {
     }
 
     export function error(message: string) {
-      //if (!inBrowser) {
-      //  warn(message + "\n\nStack Trace:\n" + Debug.backtrace());
-      //} else {
-      //  warn(message);
-      //}
       throw new Error(message);
     }
 
@@ -311,7 +306,6 @@ module J2ME {
     }
 
     export function notImplemented(message: string) {
-      log("release: " + release);
       release || Debug.assert(false, "Not Implemented " + message);
     }
 


### PR DESCRIPTION
On Firefox OS, the app could be closed by calling `window.close()` from index.html. On desktop, unless the the app window is opened by `window.open`, we could not close the app window and nothing happens.

A few missing native methods are added to avoid error when app exits.

The previous implementation suppressed `missing native method` exceptions and it causes weird issues, such as the app hangs during exiting. I changes the implementation to throw these exceptions to let us discover such kinds of bugs earlier.