### PR TITLE
Use slow path for synchronized methods to ensure we lock.

### DIFF
--- a/interpreter.ts
+++ b/interpreter.ts
@@ -1082,7 +1082,10 @@ module J2ME {
             calleeMethod = object[calleeMethodInfo.mangledName];
             var calleeTargetMethodInfo: MethodInfo = calleeMethod.methodInfo;
 
-            if (calleeTargetMethodInfo && !calleeTargetMethodInfo.isNative && calleeTargetMethodInfo.state !== MethodState.Compiled) {
+            if (calleeTargetMethodInfo &&
+                !calleeTargetMethodInfo.isSynchronized &&
+                !calleeTargetMethodInfo.isNative &&
+                calleeTargetMethodInfo.state !== MethodState.Compiled) {
               var calleeFrame = Frame.create(calleeTargetMethodInfo, [], 0);
               ArrayUtilities.popManyInto(stack, calleeTargetMethodInfo.consumeArgumentSlots, calleeFrame.local);
               frames.push(calleeFrame);
@@ -1163,7 +1166,6 @@ module J2ME {
               switch (op) {
                 case Bytecodes.INVOKEVIRTUAL:
                   if (!calleeTargetMethodInfo.hasTwoSlotArguments &&
-                      !calleeTargetMethodInfo.isSynchronized &&
                       calleeTargetMethodInfo.argumentSlots < 4) {
                     frame.patch(3, Bytecodes.INVOKEVIRTUAL, Bytecodes.RESOLVED_INVOKEVIRTUAL);
                   }


### PR DESCRIPTION
We ran into the case where invokevirtual triggered one virtual method that was not synchronized and other was. When the first one was not sync we patched it with a resolved invoke, which does not have the frame locking code so the second call would not trigger the lock.