### PR TITLE
Rename globals to avoid collisions.

### DIFF
--- a/jit/baseline.ts
+++ b/jit/baseline.ts
@@ -176,7 +176,7 @@ module J2ME {
       return classInfo.mangledName;
     }
     if (classInfo.isArrayClass) {
-      return "$AK(" + classConstant(classInfo.elementClass) + ")";
+      return "AK(" + classConstant(classInfo.elementClass) + ")";
     }
     if (classInfo.mangledName) {
       return classInfo.mangledName;
@@ -206,9 +206,9 @@ module J2ME {
     static localNames = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"];
 
     /**
-     * Make sure that none of these shadow gloal names, like "U" and "O".
+     * Make sure that none of these shadow global names, like "U" and "O".
      */
-    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "_R", "S", "T", "_U", "V", "W", "X", "Y", "Z"];
+    static stackNames = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "_O", "P", "Q", "R", "S", "T", "_U", "V", "W", "X", "Y", "Z"];
 
     constructor(methodInfo: MethodInfo, target: CompilationTarget) {
       this.methodInfo = methodInfo;
@@ -300,7 +300,7 @@ module J2ME {
       if (needsTry) {
         this.emitter.leaveAndEnter("} catch (ex) {");
         this.sp = 0;
-        this.emitPush(Kind.Reference, "$TE(ex)");
+        this.emitPush(Kind.Reference, "TE(ex)");
         if (this.hasHandlers) {
           var handlers = this.methodInfo.exception_table;
           for (var i = 0; i < handlers.length; i++) {
@@ -320,9 +320,9 @@ module J2ME {
       var check = "";
       if (handler.catch_type > 0) {
         var classInfo = this.lookupClass(handler.catch_type);
-        check = "$IOK";
+        check = "IOK";
         if (classInfo.isInterface) {
-          check = "$IOI";
+          check = "IOI";
         }
         check += "(" + this.peek(Kind.Reference) + ", " + classConstant(classInfo) + ")";
         check = " && " + check;
@@ -693,9 +693,9 @@ module J2ME {
       var value = this.pop(stackKind(kind));
       var index = this.pop(Kind.Int);
       var array = this.pop(Kind.Reference);
-      emitCheckArrayBounds && this.emitter.writeLn("$CAB(" + array + ", " + index + ");");
+      emitCheckArrayBounds && this.emitter.writeLn("CAB(" + array + ", " + index + ");");
       if (kind === Kind.Reference) {
-        emitCheckArrayStore && this.emitter.writeLn("$CAS(" + array + ", " + value + ");");
+        emitCheckArrayStore && this.emitter.writeLn("CAS(" + array + ", " + value + ");");
       }
       this.emitter.writeLn(array + "[" + index + "] = " + value + ";");
     }
@@ -703,7 +703,7 @@ module J2ME {
     emitLoadIndexed(kind: Kind) {
       var index = this.pop(Kind.Int);
       var array = this.pop(Kind.Reference);
-      emitCheckArrayBounds && this.emitter.writeLn("$CAB(" + array + ", " + index + ");");
+      emitCheckArrayBounds && this.emitter.writeLn("CAB(" + array + ", " + index + ");");
       this.emitPush(kind, array + "[" + index + "]");
     }
 
@@ -734,7 +734,7 @@ module J2ME {
           return;
         case TAGS.CONSTANT_String:
           entry = cp[entry.string_index];
-          this.emitPush(Kind.Reference, "$S(" + StringUtilities.escapeStringLiteral(entry.bytes) + ")");
+          this.emitPush(Kind.Reference, "SC(" + StringUtilities.escapeStringLiteral(entry.bytes) + ")");
           return;
         default:
           throw "Not done for: " + entry.tag;
@@ -761,9 +761,9 @@ module J2ME {
     emitCheckCast(cpi: number) {
       var object = this.peek(Kind.Reference);
       var classInfo = this.lookupClass(cpi);
-      var call = "$CCK";
+      var call = "CCK";
       if (classInfo.isInterface) {
-        call = "$CCI";
+        call = "CCI";
       }
       this.emitter.writeLn(call + "(" + object + ", " + classConstant(classInfo) + ");");
     }
@@ -771,9 +771,9 @@ module J2ME {
     emitInstanceOf(cpi: number) {
       var object = this.pop(Kind.Reference);
       var classInfo = this.lookupClass(cpi);
-      var call = "$IOK";
+      var call = "IOK";
       if (classInfo.isInterface) {
-        call = "$IOI";
+        call = "IOI";
       }
       this.emitPush(Kind.Int, call + "(" + object + ", " + classConstant(classInfo) + ") | 0");
     }
@@ -786,7 +786,7 @@ module J2ME {
       var classInfo = this.lookupClass(cpi);
       this.emitClassInitializationCheck(classInfo);
       var length = this.pop(Kind.Int);
-      this.emitPush(Kind.Reference, "$NA(" + classConstant(classInfo) + ", " + length + ")");
+      this.emitPush(Kind.Reference, "NA(" + classConstant(classInfo) + ", " + length + ")");
     }
 
     emitUnwind(pc: number, nextPC: number) {
@@ -801,12 +801,12 @@ module J2ME {
     }
 
     emitMonitorEnter(nextPC: number, object: string) {
-      this.emitter.writeLn("$ME(" + object + ");");
+      this.emitter.writeLn("ME(" + object + ");");
       this.emitUnwind(this.pc, nextPC);
     }
 
     emitMonitorExit(object: string) {
-      this.emitter.writeLn("$MX(" + object + ");");
+      this.emitter.writeLn("MX(" + object + ");");
     }
 
     emitStackOp(opcode: Bytecodes) {
@@ -863,7 +863,7 @@ module J2ME {
       var y = this.pop(result);
       var x = this.pop(result);
       if (canTrap) {
-        var checkName = result === Kind.Long ? "$CDZL" : "$CDZ";
+        var checkName = result === Kind.Long ? "CDZL" : "CDZ";
         this.emitter.writeLn(checkName + "(" + y + ");");
       }
       var v;

--- a/jit/jvm.ir.ts
+++ b/jit/jvm.ir.ts
@@ -276,7 +276,7 @@ module J2ME.C4.Backend {
   };
 
   IR.JVMString.prototype.compile = function (cx: Context): AST.Node {
-    return new AST.CallExpression(new AST.Identifier("$S"), [constant(this.value)]);
+    return new AST.CallExpression(new AST.Identifier("SC"), [constant(this.value)]);
   };
 
   IR.JVMClass.prototype.compile = function (cx: Context): AST.Node {
@@ -285,18 +285,18 @@ module J2ME.C4.Backend {
 
   IR.JVMCheckCast.prototype.compile = function (cx: Context): AST.Node {
     var object = compileValue(this.object, cx);
-    var runtimeFunction = "$CCK";
+    var runtimeFunction = "CCK";
     if (this.classInfo.isInterface) {
-      runtimeFunction = "$CCI";
+      runtimeFunction = "CCI";
     }
     return new AST.CallExpression(new AST.Identifier(runtimeFunction), [object, id(mangleClass(this.classInfo))]);
   };
 
   IR.JVMInstanceOf.prototype.compile = function (cx: Context): AST.Node {
     var object = compileValue(this.object, cx);
-    var runtimeFunction = "$IOK";
+    var runtimeFunction = "IOK";
     if (this.classInfo.isInterface) {
-      runtimeFunction = "$IOI";
+      runtimeFunction = "IOI";
     }
     return new AST.BinaryExpression("|", new AST.CallExpression(new AST.Identifier(runtimeFunction), [object, id(mangleClass(this.classInfo))]), new AST.Literal(0));
   };
@@ -305,9 +305,9 @@ module J2ME.C4.Backend {
     var value = compileValue(this.value, cx);
     var check;
     if (this.value.kind === Kind.Long) {
-      check = "$CDZL";
+      check = "CDZL";
     } else {
-      check = "$CDZ";
+      check = "CDZ";
     }
     return new AST.CallExpression(new AST.Identifier(check), [value]);
   };
@@ -345,7 +345,7 @@ module J2ME.C4.Backend {
 
   IR.JVMNewObjectArray.prototype.compile = function (cx: Context): AST.Node {
     var emitClassInitializationCheck = !CLASSES.isPreInitializedClass(this.classInfo);
-    var callee: AST.Node = call(id("$NA"), [id(mangleClass(this.classInfo)), compileValue(this.length, cx)]);
+    var callee: AST.Node = call(id("NA"), [id(mangleClass(this.classInfo)), compileValue(this.length, cx)]);
     if (emitClassInitializationCheck) {
       callee = new AST.SequenceExpression([getRuntimeClass(this.classInfo), callee]);
     }
@@ -353,11 +353,11 @@ module J2ME.C4.Backend {
   };
 
   function checkArrayBounds(array, index) {
-    return new AST.CallExpression(new AST.Identifier("$CAB"), [array, index]);
+    return new AST.CallExpression(new AST.Identifier("CAB"), [array, index]);
   }
 
   function checkArrayStore(array, value) {
-    return new AST.CallExpression(new AST.Identifier("$CAS"), [array, value]);
+    return new AST.CallExpression(new AST.Identifier("CAS"), [array, value]);
   }
 
   IR.JVMStoreIndexed.prototype.compile = function (cx: Context): AST.Node {

--- a/runtime.ts
+++ b/runtime.ts
@@ -1826,23 +1826,24 @@ var O: J2ME.Frame = null;
 
 /**
  * Runtime exports for compiled code.
+ * DO NOT use these short names outside of compiled code.
  */
-var $IOK = J2ME.instanceOfKlass;
-var $IOI = J2ME.instanceOfInterface;
+var IOK = J2ME.instanceOfKlass;
+var IOI = J2ME.instanceOfInterface;
 
-var $CCK = J2ME.checkCastKlass;
-var $CCI = J2ME.checkCastInterface;
+var CCK = J2ME.checkCastKlass;
+var CCI = J2ME.checkCastInterface;
 
-var $AK = J2ME.getArrayKlass;
-var $NA = J2ME.newArray;
-var $S = J2ME.newStringConstant;
+var AK = J2ME.getArrayKlass;
+var NA = J2ME.newArray;
+var SC = J2ME.newStringConstant;
 
-var $CDZ = J2ME.checkDivideByZero;
-var $CDZL = J2ME.checkDivideByZeroLong;
+var CDZ = J2ME.checkDivideByZero;
+var CDZL = J2ME.checkDivideByZeroLong;
 
-var $CAB = J2ME.checkArrayBounds;
-var $CAS = J2ME.checkArrayStore;
+var CAB = J2ME.checkArrayBounds;
+var CAS = J2ME.checkArrayStore;
 
-var $ME = J2ME.monitorEnter;
-var $MX = J2ME.monitorExit;
-var $TE = J2ME.translateException;
+var ME = J2ME.monitorEnter;
+var MX = J2ME.monitorExit;
+var TE = J2ME.translateException;


### PR DESCRIPTION
Class names are prefixed with `$` so we should never use anything that starts with $.