### PR TITLE
Remove un-needed callback and timeout.

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -598,13 +598,12 @@ module J2ME {
       $.pause("block");
     }
 
-    unblock(obj, queue, notifyAll, callback) {
+    unblock(obj, queue, notifyAll) {
       while (obj[queue] && obj[queue].length) {
         var ctx = obj[queue].pop();
         if (!ctx)
           continue;
-        // Wait until next tick, so that we are sure to notify all waiting.
-        (<any>window).setZeroTimeout(callback.bind(null, ctx));
+          ctx.wakeup(obj)
         if (!notifyAll)
           break;
       }
@@ -651,9 +650,7 @@ module J2ME {
         return;
       }
       object._lock = null;
-      this.unblock(object, "ready", false, function (ctx) {
-        ctx.wakeup(object);
-      });
+      this.unblock(object, "ready", false);
     }
 
     wait(object: java.lang.Object, timeout) {
@@ -685,9 +682,7 @@ module J2ME {
       if (!obj._lock || obj._lock.thread !== this.thread)
         throw $.newIllegalMonitorStateException();
 
-      this.unblock(obj, "waiting", notifyAll, function (ctx) {
-        ctx.wakeup(obj);
-      });
+      this.unblock(obj, "waiting", notifyAll);
     }
 
     bailout(methodInfo: MethodInfo, pc: number, nextPC: number, local: any [], stack: any [], lockObject: java.lang.Object) {

--- a/tests/automation.js
+++ b/tests/automation.js
@@ -70,7 +70,7 @@ var gfxTests = [
 ];
 
 var expectedUnitTestResults = [
-  { name: "pass", number: 71548 },
+  { name: "pass", number: 71549 },
   { name: "fail", number: 0 },
   { name: "known fail", number: 214 },
   { name: "unknown pass", number: 0 }

--- a/tests/javax/microedition/media/TestMediaImage.java
+++ b/tests/javax/microedition/media/TestMediaImage.java
@@ -13,6 +13,7 @@ import javax.microedition.media.control.*;
 
 public class TestMediaImage implements Testlet, PlayerListener {
     TestHarness th;
+    boolean started = false;
 
     public void test(TestHarness th) {
         this.th = th;
@@ -45,11 +46,12 @@ public class TestMediaImage implements Testlet, PlayerListener {
 
             player.start();
 
-            // We have to remove the listener now that we're done testing.
-            // Otherwise, it could receive additional calls to playerUpdate,
-            // including after we've returned, and the harness has tallied
-            // our total number of passed tests!
-            player.removePlayerListener(this);
+            synchronized (this) {
+                while (!started) {
+                    this.wait();
+                }
+            }
+            th.check(started);
 
             file.delete();
             file.close();
@@ -60,8 +62,13 @@ public class TestMediaImage implements Testlet, PlayerListener {
     }
 
     public void playerUpdate(Player player, String event, Object eventData) {
-        th.check(true);
-        player.close();
+        System.out.println(event);
+        if (event.equals("started")) {
+            started = true;
+            synchronized (this) {
+                this.notify();
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The wakeup() code will never(and should never) throw exceptions so we no longer need to do the setTimeout. Also, removing the block() callbacks helped with reduce allocations in chrome's memory profiler.