### PR TITLE
after updating the JAD/JAR, sync the fs before restarting the app

### DIFF
--- a/midp/midp.js
+++ b/midp/midp.js
@@ -869,6 +869,12 @@ Native["com/sun/cldc/isolate/Isolate.stop.(II)V"] = function(code, reason) {
           });
         }),
       ]).then(function() {
+        // Sync the fs to persistent storage to ensure we persist the update
+        // before reloading the app.
+        return new Promise(function(resolve, reject) {
+          fs.syncStore(resolve);
+        });
+      }).then(function() {
         MIDP.pendingMIDletUpdate = null;
         DumbPipe.close(DumbPipe.open("alert", "Update completed!"));
         DumbPipe.close(DumbPipe.open("reload", {}));


### PR DESCRIPTION
Otherwise, the JAD/JAR might not get synced to the persistent store before the app restarts.