### PR TITLE
make unimplemented native 'constructor' add itself to Native hash

### DIFF
--- a/midp/frameanimator.js
+++ b/midp/frameanimator.js
@@ -64,17 +64,10 @@ Native["com/nokia/mid/ui/frameanimator/FrameAnimator.unregister.()V"] = function
   this.nativeObject.unregister();
 };
 
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.drag.(II)V"] =
-  UnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.drag.(II)V");
-
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScroll.(IIIF)V"] =
-  UnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScroll.(IIIF)V");
-
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V"] =
-  UnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V");
-
-Native["com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V"] =
-  UnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V");
+addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.drag.(II)V");
+addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.kineticScroll.(IIIF)V");
+addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.limitedKineticScroll.(IIIFII)V");
+addUnimplementedNative("com/nokia/mid/ui/frameanimator/FrameAnimator.stop.()V");
 
 Native["com/nokia/mid/ui/frameanimator/FrameAnimator.isRegistered.()Z"] = function() {
   return this.nativeObject.isRegistered() ? 1 : 0;

--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -104,8 +104,7 @@ var currentlyFocusedTextEditor;
     };
 
 
-    Native["com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V"] =
-        UnimplementedNative("com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V");
+    addUnimplementedNative("com/sun/midp/lcdui/DisplayDevice.refresh0.(IIIIII)V");
 
     function swapRB(pixel) {
         return (pixel & 0xff00ff00) | ((pixel >> 16) & 0xff) | ((pixel & 0xff) << 16);
@@ -1660,11 +1659,8 @@ var currentlyFocusedTextEditor;
         this.setCaretPosition(this.textEditor.getSize());
     };
 
-    Native["com/nokia/mid/ui/TextEditor.getLineMarginHeight.()I"] =
-        UnimplementedNative("com/nokia/mid/ui/TextEditor.getLineMarginHeight.()I", 0);
-
-    Native["com/nokia/mid/ui/TextEditor.getVisibleContentPosition.()I"] =
-        UnimplementedNative("com/nokia/mid/ui/TextEditor.getVisibleContentPosition.()I", 0);
+    addUnimplementedNative("com/nokia/mid/ui/TextEditor.getLineMarginHeight.()I", 0);
+    addUnimplementedNative("com/nokia/mid/ui/TextEditor.getVisibleContentPosition.()I", 0);
 
     Native["com/nokia/mid/ui/TextEditor.getContentHeight.()I"] = function() {
         return this.textEditor.getContentHeight();
@@ -1922,29 +1918,21 @@ var currentlyFocusedTextEditor;
         return nextMidpDisplayableId++;
     };
 
-    Native["javax/microedition/lcdui/FormLFImpl.setScrollPosition0.(I)V"] =
-        UnimplementedNative("javax/microedition/lcdui/FormLFImpl.setScrollPosition0.(I)V");
+    addUnimplementedNative("javax/microedition/lcdui/FormLFImpl.setScrollPosition0.(I)V");
+    addUnimplementedNative("javax/microedition/lcdui/FormLFImpl.getScrollPosition0.()I", 0);
 
-    Native["javax/microedition/lcdui/FormLFImpl.getScrollPosition0.()I"] =
-        UnimplementedNative("javax/microedition/lcdui/FormLFImpl.getScrollPosition0.()I", 0);
+    addUnimplementedNative(
+        "javax/microedition/lcdui/FormLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I",
+        function() { return nextMidpDisplayableId++ }
+    );
 
-    Native["javax/microedition/lcdui/FormLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I"] =
-        UnimplementedNative(
-            "javax/microedition/lcdui/FormLFImpl.createNativeResource0.(Ljava/lang/String;Ljava/lang/String;)I",
-            function() { return nextMidpDisplayableId++ }
-        );
+    addUnimplementedNative("javax/microedition/lcdui/FormLFImpl.showNativeResource0.(IIII)V");
+    addUnimplementedNative("javax/microedition/lcdui/FormLFImpl.getViewportHeight0.()I", 0);
 
-    Native["javax/microedition/lcdui/FormLFImpl.showNativeResource0.(IIII)V"] =
-        UnimplementedNative("javax/microedition/lcdui/FormLFImpl.showNativeResource0.(IIII)V");
-
-    Native["javax/microedition/lcdui/FormLFImpl.getViewportHeight0.()I"] =
-        UnimplementedNative("javax/microedition/lcdui/FormLFImpl.getViewportHeight0.()I", 0);
-
-    Native["javax/microedition/lcdui/StringItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjava/lang/String;ILjavax/microedition/lcdui/Font;)I"] =
-        UnimplementedNative(
-            "javax/microedition/lcdui/StringItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjava/lang/String;ILjavax/microedition/lcdui/Font;)I",
-            function() { return nextMidpDisplayableId++ }
-        );
+    addUnimplementedNative(
+        "javax/microedition/lcdui/StringItemLFImpl.createNativeResource0.(ILjava/lang/String;ILjava/lang/String;ILjavax/microedition/lcdui/Font;)I",
+        function() { return nextMidpDisplayableId++ }
+    );
 
     Native["javax/microedition/lcdui/ItemLFImpl.setSize0.(III)V"] = function(nativeId, w, h) {
         console.warn("javax/microedition/lcdui/ItemLFImpl.setSize0.(III)V not implemented");
@@ -1962,20 +1950,11 @@ var currentlyFocusedTextEditor;
         console.warn("javax/microedition/lcdui/ItemLFImpl.hide0.(I)V not implemented");
     };
 
-    Native["javax/microedition/lcdui/ItemLFImpl.getMinimumWidth0.(I)I"] =
-        UnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getMinimumWidth0.(I)I", 10);
-
-    Native["javax/microedition/lcdui/ItemLFImpl.getMinimumHeight0.(I)I"] =
-        UnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getMinimumHeight0.(I)I", 10);
-
-    Native["javax/microedition/lcdui/ItemLFImpl.getPreferredWidth0.(II)I"] =
-        UnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getPreferredWidth0.(II)I", 10);
-
-    Native["javax/microedition/lcdui/ItemLFImpl.getPreferredHeight0.(II)I"] =
-        UnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getPreferredHeight0.(II)I", 10);
-
-    Native["javax/microedition/lcdui/ItemLFImpl.delete0.(I)V"] =
-        UnimplementedNative("javax/microedition/lcdui/ItemLFImpl.delete0.(I)V");
+    addUnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getMinimumWidth0.(I)I", 10);
+    addUnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getMinimumHeight0.(I)I", 10);
+    addUnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getPreferredWidth0.(II)I", 10);
+    addUnimplementedNative("javax/microedition/lcdui/ItemLFImpl.getPreferredHeight0.(II)I", 10);
+    addUnimplementedNative("javax/microedition/lcdui/ItemLFImpl.delete0.(I)V");
 
     var BACK = 2;
     var CANCEL = 3;

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -1342,17 +1342,8 @@ Native["com/sun/j2me/content/AppProxy.isInSvmMode.()Z"] = function() {
     return 0;
 };
 
-Native["com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V"] =
-    UnimplementedNative("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V");
-
-Native["com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I"] =
-    UnimplementedNative("com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I", 0);
-
-Native["com/sun/j2me/content/InvocationStore.getByTid0.(Lcom/sun/j2me/content/InvocationImpl;II)I"] =
-    UnimplementedNative("com/sun/j2me/content/InvocationStore.getByTid0.(Lcom/sun/j2me/content/InvocationImpl;II)I", 0);
-
-Native["com/sun/j2me/content/InvocationStore.resetFlags0.(I)V"] =
-    UnimplementedNative("com/sun/j2me/content/InvocationStore.resetFlags0.(I)V");
-
-Native["com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V"] =
-    UnimplementedNative("com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V");
+addUnimplementedNative("com/sun/j2me/content/InvocationStore.setCleanup0.(ILjava/lang/String;Z)V");
+addUnimplementedNative("com/sun/j2me/content/InvocationStore.get0.(Lcom/sun/j2me/content/InvocationImpl;ILjava/lang/String;IZ)I", 0);
+addUnimplementedNative("com/sun/j2me/content/InvocationStore.getByTid0.(Lcom/sun/j2me/content/InvocationImpl;II)I", 0);
+addUnimplementedNative("com/sun/j2me/content/InvocationStore.resetFlags0.(I)V");
+addUnimplementedNative("com/sun/j2me/content/AppProxy.midletIsRemoved.(ILjava/lang/String;)V");

--- a/native.js
+++ b/native.js
@@ -1049,7 +1049,7 @@ Native["com/nokia/mid/impl/jms/core/Launcher.handleContent.(Ljava/lang/String;)V
     }));
 };
 
-function UnimplementedNative(signature, returnValue) {
+function addUnimplementedNative(signature, returnValue) {
     var doNotWarn;
 
     if (typeof returnValue === "function") {
@@ -1064,5 +1064,5 @@ function UnimplementedNative(signature, returnValue) {
         return doNotWarn();
     };
 
-    return function() { return warnOnce() };
+    Native[signature] = function() { return warnOnce() };
 }


### PR DESCRIPTION
This simplifies UnimplementedNative declarations by eliminating the need to hardcode the method signature twice.