### PR TITLE
miscellaneous startup optimizations

### DIFF
--- a/java/Makefile
+++ b/java/Makefile
@@ -11,7 +11,7 @@ classes.jar: $(SRCS) $(JPP_DESTS)
 	mkdir build build-src
 	cp -a cldc1.1.1/. vm/. midp/. jsr-075/. build-src/
 	cp -a custom/. build-src/
-	javac -cp build-src -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build `find ./build-src -name *.java` > /dev/null
+	javac -cp build-src -g:none -source 1.3 -target 1.3 -bootclasspath "" -extdirs "" -d ./build `find ./build-src -name *.java` > /dev/null
 	cd build && jar cvf0 ../classes.jar *
 	jar uvf0 classes.jar $(EXTRA)
 	rm -rf build build-src

--- a/java/custom/com/nokia/mid/s40/bg/BGUtils.java
+++ b/java/custom/com/nokia/mid/s40/bg/BGUtils.java
@@ -3,6 +3,9 @@ package com.nokia.mid.s40.bg;
 import com.sun.midp.main.MIDletSuiteUtils;
 
 class WaitUserInteractionThread extends Thread {
+    public WaitUserInteractionThread() {
+        setPriority(Thread.MAX_PRIORITY);
+    }
     public void run() {
         BGUtils.waitUserInteraction();
         BGUtils.startMIDlet();

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -12,6 +12,7 @@ mkdir $PACKAGE_DIR/build
 # setup the root
 cp *.js *.html *.webapp $PACKAGE_DIR/.
 cp build/j2me.js $PACKAGE_DIR/build/.
+cp build/classes.jar.js $PACKAGE_DIR/build/.
 
 # copy over jars/jads that are used for the webapp
 # NB: we could be smart about this and parse the manifest, patches welcome!


### PR DESCRIPTION
1. Bumping the priority of WaitUserInteractionThread enables it to resume more quickly after the localmsg server is created, shaving up to a second off the time it takes to start the foreground midlet on my Flame.
2. The *-g:none* flag to javac removes about 300K of debugging info from classes.jar, which should save a bit of time loading that file.
3. Packaging classes.jar.js should save time due to reduced interpretation.
