### PR TITLE
ignore messages from different origin (fixes #909)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,15 @@
   });
 })();
 
+var childOrigin;
+document.getElementById("mozbrowser").addEventListener("mozbrowserlocationchange", function(event) {
+  childOrigin = new URL(event.detail).origin;
+  var parentOrigin = document.location.origin;
+  if (childOrigin !== parentOrigin) {
+    console.warn("on location change: child origin " + childOrigin + " !== parent origin " + parentOrigin);
+  }
+});
+
 var DumbPipe = {
   // Functions that handle requests to open a pipe, indexed by type.
   openers: {},
@@ -38,6 +47,12 @@ var DumbPipe = {
   },
 
   handleEvent: function(event) {
+    var parentOrigin = document.location.origin;
+    if (childOrigin !== parentOrigin) {
+      console.error("on show modal prompt: child origin " + childOrigin + " !== parent origin " + parentOrigin);
+      return;
+    }
+
     if (event.detail.promptType == "custom-prompt") {
       console.warn("unresponsive script warning; figure out how to handle");
       return;

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@
   });
 })();
 
-var childOrigin;
+var childOrigin = document.location.origin;
 document.getElementById("mozbrowser").addEventListener("mozbrowserlocationchange", function(event) {
   childOrigin = new URL(event.detail).origin;
   var parentOrigin = document.location.origin;


### PR DESCRIPTION
Navigation in the child shouldn't happen, but this is defense in depth in case it does. Unfortunately, I can't check *event.target.origin*, as suggested in #909, because the child doesn't *postMessage* to the parent. So instead I track the child's location with *mozbrowserlocationchange* and ignore the message if the parent and child origins differ.

This one is difficult to test automatically, but I've confirmed that it works as expected with these manual test steps:

1. load some midlet in a browser tab, f.e. http://localhost:8000/index.html?midletClassName=midlets.InitMidlet&jars=tests/tests.jar
2. install [tcpsocketpup](https://github.com/mykmelez/tcpsocketpup/releases/latest) and use it to give the URL mozbrowser permissions
3. reload the tab
4. open Developer Tools and switch to the child frame: `cd(frames[0])`
5. evaluate `window.alert(JSON.stringify({"command":"open","type":"alert","message":"Hello, world!"}))`: an alert dialog should appear that says "Hello, world!"
6. navigate the child frame to another origin: `document.location = "http://www.mozilla.org/"`
7. evaluate `window.alert(JSON.stringify({"command":"open","type":"alert","message":"Hello, world!"}))` again: no alert dialog should appear

After step 6, you might also see this warning in the console: "on location change: child origin https://www.mozilla.org !== parent origin http://localhost:8000", and after step 7, you might see the error: ""on show modal prompt: child origin https://www.mozilla.org !== parent origin http://localhost:8000". I did see them once, but another time I didn't (which I suspect is an issue with Firefox's Web Console). Nevertheless, under no circumstances should you see the "Hello, world!" alert again.
