### PR TITLE
Fix non fullscreen display

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -63,11 +63,11 @@ var currentlyFocusedTextEditor;
     };
 
     Native["com/sun/midp/lcdui/DisplayDevice.getScreenWidth0.(I)I"] = function(id) {
-        return MIDP.ScreenWidth;
+        return MIDP.Context2D.canvas.width;
     };
 
     Native["com/sun/midp/lcdui/DisplayDevice.getScreenHeight0.(I)I"] = function(id) {
-        return MIDP.ScreenHeight;
+        return MIDP.Context2D.canvas.height;
     };
 
     Native["com/sun/midp/lcdui/DisplayDevice.displayStateChanged0.(II)V"] = function(hardwareId, state) {

--- a/midp/midp.js
+++ b/midp/midp.js
@@ -551,11 +551,6 @@ MIDP.Context2D = (function() {
       c.width = window.innerWidth;
       c.height = window.innerHeight;
       document.documentElement.classList.add('autosize');
-      c.style.position = "fixed";
-      c.style.top = "0px";
-      c.style.left = "0px";
-      c.style.height = c.height + "px";
-      c.style.width = c.width + "px";
       window.addEventListener("resize", MIDP.onWindowResize);
     } else {
       document.documentElement.classList.add('debug-mode');


### PR DESCRIPTION
https://github.com/andreasgal/j2me.js/pull/966 makes canvas hold its position and not resize. It fixed the bug - black bar appears after opening text editor, but introduces two side effects when we set `autoresize=1`:

1. app, which is not in full screen, cannot display its whole content. The reason is `DisplayDevice.getScreenHeight0()` should return canvas height, but not the actual screen height. The app mistaken the screen height for the canvas height and draws out of the canvas area.

2. The system back button doesn't stay at the bottom but at the top.

The pull request reverts related changes.

As https://github.com/andreasgal/j2me.js/pull/972 already fixed the bug that causes canvas to change position and resize, so it's safe to do the reverting.