### PR TITLE
miscellaneous new text editor fixes

### DIFF
--- a/midp/text_editor.js
+++ b/midp/text_editor.js
@@ -25,6 +25,7 @@ var TextEditorProvider = (function() {
         id: -1,
         selectionRange: [0, 0],
         focused: false,
+        oninputCallback: null,
 
         // opaque white
         backgroundColor:  0xFFFFFFFF | 0,
@@ -597,7 +598,8 @@ var TextEditorProvider = (function() {
              "backgroundColor", "foregroundColor",
              "attached",
              "content",
-             "font"].forEach(function(attr) {
+             "font",
+             "oninputCallback"].forEach(function(attr) {
                 newEditor[attr] = oldEditor[attr];
             });
 

--- a/style/main.css
+++ b/style/main.css
@@ -333,7 +333,10 @@ form[role="dialog"][data-type="confirm"].lcdui-alert section {
   visibility: visible;
 }
 
-#textarea-editor {
+div.text-editor {
+  margin: 0;
+  padding: 0;
+  box-sizing:  border-box;
   word-break: break-all;
   word-wrap: break-word;
   overflow: auto;


### PR DESCRIPTION
Fix `getContentHeight()` to make it more accurate. 
There is a midlet that increases the TextEditor unlimitedly, but Nokia Asha's implementation doesn't allow that, so I set a limit of `getContentHeight()` to 130.

Also it fixes a mistake that when the type of TextEditor has changed, I forgot to set `oninputCallback` and cause TextEditorThread don't get input notification.