### PR TITLE
Don't set image-rendering to crisp-edges

### DIFF
--- a/main.html.in
+++ b/main.html.in
@@ -157,7 +157,7 @@
         <h1 id="display_title"></h1>
       </header>
       <div id="main" role="main">
-        <canvas id="canvas" style="image-rendering: -moz-crisp-edges"></canvas>
+        <canvas id="canvas"></canvas>
         <input id="password-editor" class="text-editor" type="password">
         <div id="textarea-editor" class="text-editor" contenteditable="true"></div>
         <!-- The hidden textarea editor is used to measure the content height -->


### PR DESCRIPTION
The canvas looks ugly with image-rendering set to crisp-edges.