### PR TITLE
Use textContent to avoid html insertion.

### DIFF
--- a/midp/gfx.js
+++ b/midp/gfx.js
@@ -1930,7 +1930,9 @@ var currentlyFocusedTextEditor;
                 }
                 var li = document.createElement("li");
                 var text = util.fromJavaString(command.klass.classInfo.getField("I.shortLabel.Ljava/lang/String;").get(command));
-                li.innerHTML = "<a>" + text + "</a>";
+                var a = document.createElement("a");
+                a.textContent = text;
+                li.appendChild(a);
 
                 li.onclick = function(e) {
                     e.preventDefault();


### PR DESCRIPTION
Happened to notice this while looking for something else. We should probably review all uses of innerHTML.