### PR TITLE
mark additional methods as yielding

### DIFF
--- a/jit/analyze.ts
+++ b/jit/analyze.ts
@@ -45,6 +45,7 @@ module J2ME {
     "com/nokia/mid/s40/bg/BGUtils.waitUserInteraction.()V": YieldReason.Root,
     "org/mozilla/io/LocalMsgConnection.init.(Ljava/lang/String;)V": YieldReason.Root,
     "org/mozilla/io/LocalMsgConnection.receiveData.([B)I": YieldReason.Root,
+    "org/mozilla/io/LocalMsgConnection.waitConnection.()V": YieldReason.Root,
     "com/sun/mmedia/PlayerImpl.nRealize.(ILjava/lang/String;)Z": YieldReason.Root,
     "com/sun/mmedia/DirectRecord.nPause.(I)I": YieldReason.Root,
     "com/sun/mmedia/DirectRecord.nStop.(I)I": YieldReason.Root,
@@ -61,6 +62,7 @@ module J2ME {
     "java/lang/Class.invoke_clinit.()V": YieldReason.Root,
     "java/lang/Class.newInstance.()Ljava/lang/Object;": YieldReason.Root,
     "java/lang/Thread.yield.()V": YieldReason.Root,
+    "java/lang/Thread.start0.()V": YieldReason.Root,
     // Test Files:
     "gnu/testlet/vm/NativeTest.throwExceptionAfterPause.()V": YieldReason.Root,
     "gnu/testlet/vm/NativeTest.returnAfterPause.()I": YieldReason.Root,


### PR DESCRIPTION
@mbebenita found some more yielding methods that weren't marked as such (cherry picked from commit e26750f558d001cb961d2ba37b643a4427d157ae).
