### PR TITLE
Replace todo with fail for a test that we are passing

### DIFF
--- a/tests/javax/microedition/rms/TestRecordStore.java
+++ b/tests/javax/microedition/rms/TestRecordStore.java
@@ -119,7 +119,8 @@ public class TestRecordStore implements Testlet {
             th.check(record.length, largeData.length);
             th.check(i, record.length);
         } catch (Exception e) {
-            th.todo(false, "Unexpected exception: " + e);
+            th.fail("Unexpected exception: " + e);
+            e.printStackTrace();
         }
 
         store.closeRecordStore();


### PR DESCRIPTION
I''ve found this while investigating a related issue.
Since we're passing this test, we shouldn't use todo but fail.