### PR TITLE
log context ID to Web Console; fix native console logging

### DIFF
--- a/libs/console.js
+++ b/libs/console.js
@@ -179,7 +179,7 @@
     push: function(item) {
       if (item.matchesCurrentFilters()) {
         this.flush(); // Preserve order w/r/t console.print().
-        windowConsole[item.levelName].apply(windowConsole, item.args);
+        windowConsole[item.levelName].apply(windowConsole, [item.message]);
       }
     },
 
@@ -202,7 +202,7 @@
   NativeConsole.prototype = {
     push: function(item) {
       if (item.matchesCurrentFilters()) {
-        dumpLine(item.message);
+        dump(item.message);
       }
     }
   };

--- a/libs/console.js
+++ b/libs/console.js
@@ -202,7 +202,7 @@
   NativeConsole.prototype = {
     push: function(item) {
       if (item.matchesCurrentFilters()) {
-        dump(item.message);
+        dump(item.message + "\n");
       }
     }
   };


### PR DESCRIPTION
This adds the context ID to the messages on the Web Console in addition to the in-page console. Note that you have to set the *logConsole* parameter to something other than simply `web` in order for this to work, as the simple value `web` causes the console object to hook itself directly to the Web Console, bypassing the code that formats the message with the ID prefix.

For example, you could set *logConsole* to `web,native`. In which case you'll need the second fix in this patch, which makes the native console logger call *dump* instead of the nonexistent *dumpLine*.

