### PR TITLE
Fix text editor secrity issue

### DIFF
--- a/midp/text_editor.js
+++ b/midp/text_editor.js
@@ -251,21 +251,24 @@ var TextEditorProvider = (function() {
                 var range = this.getSelectionRange();
 
                 // Remove the last <br> tag if any.
-                var content = this.textEditorElem.innerHTML;
-                var lastBr = content.lastIndexOf("<br>");
+                var html = this.textEditorElem.innerHTML;
+                var lastBr = html.lastIndexOf("<br>");
                 if (lastBr !== -1) {
-                    content = content.substring(0, lastBr);
+                    html = html.substring(0, lastBr);
                 }
 
-                // Replace <br> by \n
-                content = content.replace("<br>", "\n", "g");
+                // Replace <br> by \n so that textContent attribute doesn't
+                // strip new lines.
+                html = html.replace("<br>", "\n", "g");
 
                 // Convert the emoji images back to characters.
                 // The original character is stored in the alt attribute of its
                 // object tag with the format of <object ... name='X' ..>.
-                content = content.replace(/<object[^>]*name="(\S*)"[^>]*><\/object>/g, '$1');
+                html = html.replace(/<object[^>]*name="(\S*)"[^>]*><\/object>/g, '$1');
 
-                this.setContent(content);
+                this.textEditorElem.innerHTML = html;
+
+                this.setContent(this.textEditorElem.textContent);
 
                 // Restore the current selection after updating emoji images.
                 this.setSelectionRange(range[0], range[1]);
@@ -292,6 +295,10 @@ var TextEditorProvider = (function() {
 
             this.content = content;
 
+            // Escape the content to avoid malicious injection via innerHTML.
+            this.textEditorElem.textContent = content;
+            var html = this.textEditorElem.innerHTML;
+
             if (!this.visible) {
                 return;
             }
@@ -312,7 +319,7 @@ var TextEditorProvider = (function() {
             }.bind(this);
 
             // Replace "\n" by <br>
-            var html = content.replace("\n", "<br>", "g");
+            html = html.replace("\n", "<br>", "g");
 
             html = html.replace(emoji.regEx, toImg) + "<br>";
 

--- a/tests/com/nokia/mid/ui/TestTextEditor.java
+++ b/tests/com/nokia/mid/ui/TestTextEditor.java
@@ -12,12 +12,13 @@ import javax.microedition.lcdui.TextField;
 
 public class TestTextEditor extends Canvas implements Testlet {
     public void testConstraints(TestHarness th, int constraints, int tolerance) {
-        TextEditor textEditor = new TextEditor("Hello, world!", 20, 0, 100, 24);
+        String text = "</div>Hello, world!";
+        TextEditor textEditor = new TextEditor(text, 20, 0, 100, 24);
         textEditor.setVisible(true);
 
-        th.check(textEditor.getContent(), "Hello, world!");
+        th.check(textEditor.getContent(), text);
         th.check(textEditor.getMaxSize(), 20);
-        th.check(textEditor.getCaretPosition(), 13);
+        th.check(textEditor.getCaretPosition(), text.length());
 
         textEditor.setConstraints(constraints);
         th.check(textEditor.getConstraints(), constraints);


### PR DESCRIPTION
Fix two bugs:
1. The styled text, such as <span>ABC</span>, from copy paste will be converted to plain text before insertion.
2. The text content inserted by `TextEditor.setContent()`, `TextEditor.insert()` and so on will be escaped, such as `"<span></span>"` is escaped to `"&lt;span&gt;&lt;/span&gt;"`.